### PR TITLE
Fix catastrophic backtracking

### DIFF
--- a/rgb2hex.js
+++ b/rgb2hex.js
@@ -21,15 +21,15 @@
             throw new Error('given color (' + color + ') isn\'t a valid rgb or rgba color');
         }
 
-        var red = parseInt(digits[1]);
-        var green = parseInt(digits[2]);
-        var blue = parseInt(digits[3]);
+        var red = parseInt(digits[1], 10);
+        var green = parseInt(digits[2], 10);
+        var blue = parseInt(digits[3], 10);
         var alpha = digits[4] ? /([0-9\.]+)/.exec(digits[4])[0] : '1';
         var rgb = ((blue | green << 8 | red << 16) | 1 << 24).toString(16).slice(1);
 
         // parse alpha value into float
         if(alpha.substr(0,1) === '.') {
-            alpha = parseFloat('0' + alpha, 10);
+            alpha = parseFloat('0' + alpha);
         }
 
         // limit alpha value to 1
@@ -38,7 +38,7 @@
         }
 
         // cut alpha value after 2 digits after comma
-        alpha = parseFloat(Math.round(alpha * 100), 10) / 100;
+        alpha = parseFloat(Math.round(alpha * 100)) / 100;
 
         return {
             hex: '#' + rgb.toString(16),

--- a/rgb2hex.js
+++ b/rgb2hex.js
@@ -14,17 +14,17 @@
         }
 
         // parse input
-        var digits = /(.*?)rgb(a)*\((\d+),(\d+),(\d+)(,[0-9]*\.*[0-9]+)*\)/.exec(color.replace(/\s+/g,''));
+        var digits = /^rgba?\((\d+),(\d+),(\d+)(,[0-1]?\.?[0-9]+)?\)$/.exec(color.replace(/\s+/g,''));
 
         if(!digits) {
             // or throw error if input isn't a valid rgb(a) color
             throw new Error('given color (' + color + ') isn\'t a valid rgb or rgba color');
         }
 
-        var red = parseInt(digits[3]);
-        var green = parseInt(digits[4]);
-        var blue = parseInt(digits[5]);
-        var alpha = digits[6] ? /([0-9\.]+)/.exec(digits[6])[0] : '1';
+        var red = parseInt(digits[1]);
+        var green = parseInt(digits[2]);
+        var blue = parseInt(digits[3]);
+        var alpha = digits[4] ? /([0-9\.]+)/.exec(digits[4])[0] : '1';
         var rgb = ((blue | green << 8 | red << 16) | 1 << 24).toString(16).slice(1);
 
         // parse alpha value into float
@@ -41,9 +41,9 @@
         alpha = parseFloat(Math.round(alpha * 100), 10) / 100;
 
         return {
-            hex: digits[1] + '#' + rgb.toString(16),
+            hex: '#' + rgb.toString(16),
             alpha: alpha
-        }
+        };
 
     };
 


### PR DESCRIPTION
Fixes uncontrolled resource consumption vulnerability referenced in #1. ([ref1](https://nodesecurity.io/advisories/647), [ref2](https://snyk.io/vuln/npm:rgb2hex:20180429))

Please note:
* The regex is now a bit stricter, but I think this is fine for the vast majority of use cases (at least the valid ones), and all tests pass; I'll let you decide if it warrants a patch or minor version bump.
* I also fixed some minor `parseInt`/`parseFloat` (mis)usage; no functional change there.
* I did NOT update the minified file, since I don't know what tool or options you prefer to use for that.