### PR TITLE
Fix for issue #4: convert the color value even with text following it

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var rgb2hex = module.exports = function rgb2hex(color) {
     }
 
     // parse input
-    var digits = /^rgba?\((\d+),(\d+),(\d+)(,(\d+)?\.?(\d+))?\);?$/.exec(color.replace(/\s+/g,''));
+    var digits = /^rgba?\((\d+),(\d+),(\d+)(,(\d+)?\.?(\d+))?\);?/.exec(color.replace(/\s+/g,''));
 
     if(!digits) {
         // or throw error if input isn't a valid rgb(a) color

--- a/rgb2hex.js
+++ b/rgb2hex.js
@@ -14,7 +14,7 @@
         }
 
         // parse input
-        var digits = /^rgba?\((\d+),(\d+),(\d+)(,(\d+)?\.?(\d+))?\);?$/.exec(color.replace(/\s+/g,''));
+        var digits = /^rgba?\((\d+),(\d+),(\d+)(,(\d+)?\.?(\d+))?\);?/.exec(color.replace(/\s+/g,''));
 
         if(!digits) {
             // or throw error if input isn't a valid rgb(a) color

--- a/test/rgb2hex.test.js
+++ b/test/rgb2hex.test.js
@@ -84,6 +84,13 @@ describe('rgb2hex should', () => {
             expect(rgb2hex(input).alpha).not.toBeGreaterThan(1)
         })
 
+        it('works with attributes right after', () => {
+          const rgbwithtext = 'rgb(0,0,0)somethingelse'
+          const rgbawithtext = 'rgba(0,0,0)somethingelse'
+
+          expect(rgb2hex(rgbwithtext).hex).toEqual('#000000')
+          expect(rgb2hex(rgbawithtext).hex).toEqual('#000000')
+        })
     })
 
     describe('not care about', () => {


### PR DESCRIPTION
I saw the same behavior as discussed in issue #4. I believe the issue is that we assume that there will be nothing following the color value, which is not true for me and as seen in the issue.

Added unit tests to cover both rgb and rgba colors with attribute text following it (which happens with webdriverio's getCssProperty).